### PR TITLE
[BUZZOK-27678] Replace ujson with orjson

### DIFF
--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -2,7 +2,7 @@ import abc
 import logging
 from typing import Any, Dict, List, Optional, Union
 
-import ujson
+import orjson
 
 from pymilvus.exceptions import DataTypeNotMatchException, ExceptionsMessage
 from pymilvus.settings import Config
@@ -60,7 +60,7 @@ class FieldSchema:
         for type_param in raw.type_params:
             if type_param.key == "params":
                 try:
-                    self.params[type_param.key] = ujson.loads(type_param.value)
+                    self.params[type_param.key] = orjson.loads(type_param.value)
                 except Exception as e:
                     logger.error(
                         f"FieldSchema::__pack::65::Failed to load JSON type_param.value: {e}, original data: {type_param.value}"
@@ -89,7 +89,7 @@ class FieldSchema:
         for index_param in raw.index_params:
             if index_param.key == "params":
                 try:
-                    index_dict[index_param.key] = ujson.loads(index_param.value)
+                    index_dict[index_param.key] = orjson.loads(index_param.value)
                 except Exception as e:
                     logger.error(
                         f"FieldSchema::__pack::92::Failed to load JSON index_param.value: {e}, original data: {index_param.value}"

--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -4,7 +4,7 @@ import struct
 from typing import Any, Dict, Iterable, List, Optional
 
 import numpy as np
-import ujson
+import orjson
 
 from pymilvus.exceptions import (
     DataNotMatchException,
@@ -204,7 +204,7 @@ def convert_to_json(obj: object):
 
     processed_obj = preprocess_numpy_types(obj)
 
-    return ujson.dumps(processed_obj, ensure_ascii=False).encode(Config.EncodeProtocol)
+    return orjson.dumps(processed_obj)
 
 
 def convert_to_json_arr(objs: List[object], field_info: Any):
@@ -817,7 +817,7 @@ def extract_row_data_from_fields_data(
                 entity_row_data[field_data.field_name] = None
                 return
             try:
-                json_dict = ujson.loads(field_data.scalars.json_data.data[index])
+                json_dict = orjson.loads(field_data.scalars.json_data.data[index])
             except Exception as e:
                 logger.error(
                     f"extract_row_data_from_fields_data::Failed to load JSON data: {e}, original data: {field_data.scalars.json_data.data[index]}"

--- a/pymilvus/client/search_result.py
+++ b/pymilvus/client/search_result.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import ujson
+import orjson
 
 from pymilvus.client.types import DataType
 from pymilvus.exceptions import MilvusException
@@ -148,7 +148,7 @@ class HybridHits(list):
                             json_data = field_data.scalars.json_data.data[idx]
                             try:
                                 json_dict_list = (
-                                    ujson.loads(json_data) if json_data is not None else None
+                                    orjson.loads(json_data) if json_data is not None else None
                                 )
                             except Exception as e:
                                 logger.error(
@@ -356,7 +356,7 @@ class SearchResult(list):
                 for item in res:
                     if item is not None:
                         try:
-                            json_dict_list.append(ujson.loads(item))
+                            json_dict_list.append(orjson.loads(item))
                         except Exception as e:
                             logger.error(
                                 f"SearchResult::_get_fields_by_range::Failed to load JSON item: {e}, original item: {item}"

--- a/pymilvus/client/types.py
+++ b/pymilvus/client/types.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 from typing import Any, ClassVar, Dict, List, Optional, TypeVar, Union
 
 import numpy as np
-import ujson
+import orjson
 
 from pymilvus.exceptions import (
     AutoIDException,
@@ -1064,7 +1064,7 @@ class HybridExtraList(list):
                 row_data[field_data.field_name] = None
                 return
             try:
-                json_dict = ujson.loads(field_data.scalars.json_data.data[index])
+                json_dict = orjson.loads(field_data.scalars.json_data.data[index])
             except Exception as e:
                 logger.error(
                     f"HybridExtraList::_extract_lazy_fields::Failed to load JSON data: {e}, original data: {field_data.scalars.json_data.data[index]}"

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -5,10 +5,11 @@ from copy import deepcopy
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
-import ujson
+import orjson
 
 from pymilvus.exceptions import MilvusException, ParamError
 from pymilvus.grpc_gen.common_pb2 import Status
+from pymilvus.settings import Config
 
 from .constants import LOGICAL_BITS, LOGICAL_BITS_MASK
 from .types import DataType
@@ -300,7 +301,7 @@ def get_server_type(host: str):
 
 
 def dumps(v: Union[dict, str]) -> str:
-    return ujson.dumps(v) if isinstance(v, dict) else str(v)
+    return orjson.dumps(v).decode(Config.EncodeProtocol) if isinstance(v, dict) else str(v)
 
 
 class SciPyHelper:

--- a/pymilvus/orm/partition.py
+++ b/pymilvus/orm/partition.py
@@ -12,14 +12,15 @@
 
 from typing import Dict, List, Optional, TypeVar, Union
 
+import orjson
 import pandas as pd
-import ujson
 
 from pymilvus.client import utils
 from pymilvus.client.abstract import BaseRanker
 from pymilvus.client.search_result import SearchResult
 from pymilvus.client.types import Replica
 from pymilvus.exceptions import MilvusException
+from pymilvus.settings import Config
 
 from .mutation import MutationResult
 
@@ -57,13 +58,13 @@ class Partition:
             conn.create_partition(self._collection.name, self.name, **kwargs)
 
     def __repr__(self) -> str:
-        return ujson.dumps(
+        return orjson.dumps(
             {
                 "name": self.name,
                 "collection_name": self._collection.name,
                 "description": self.description,
             }
-        )
+        ).decode(Config.EncodeProtocol)
 
     def _get_connection(self):
         return self._collection._get_connection()

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -13,8 +13,8 @@
 import copy
 from typing import Any, Dict, List, Optional, Union
 
+import orjson
 import pandas as pd
-import ujson
 from pandas.api.types import is_list_like, is_scalar
 
 from pymilvus.client.types import FunctionType
@@ -34,6 +34,7 @@ from pymilvus.exceptions import (
     SchemaNotReadyException,
 )
 from pymilvus.grpc_gen import schema_pb2 as schema_types
+from pymilvus.settings import Config
 
 from .constants import COMMON_TYPE_PARAMS
 from .types import (
@@ -415,7 +416,7 @@ class FieldSchema:
 
         for key in ["analyzer_params", "multi_analyzer_params"]:
             if key in self._kwargs and isinstance(self._kwargs[key], dict):
-                self._kwargs[key] = ujson.dumps(self._kwargs[key])
+                self._kwargs[key] = orjson.dumps(self._kwargs[key]).decode(Config.EncodeProtocol)
 
         self._parse_type_params()
         self.is_function_output = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ dependencies=[
     "setuptools>69",
     "setuptools<70.1;python_version<='3.8'",
     "grpcio>=1.66.2,!=1.68.0,!=1.68.1,!=1.69.0,!=1.70.0,!=1.70.1,!=1.71.0,!=1.72.1,!=1.73.0",
+    "orjson>=3.11.3",
     "protobuf>=5.27.2", # aligned with grpcio-tools generated codes
     "python-dotenv>=1.0.1, <2.0.0",
-    "ujson>=2.0.0",
     "pandas>=1.2.4",
     "numpy<1.25.0;python_version<='3.8'",
     "milvus-lite>=2.4.0;sys_platform!='win32'",

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -4,7 +4,7 @@ import random
 from typing import Dict
 
 import pytest
-import ujson
+import orjson
 from pymilvus.client.search_result import Hit, Hits, HybridHits, SearchResult
 from pymilvus.client.types import DataType
 from pymilvus.grpc_gen import schema_pb2
@@ -157,11 +157,11 @@ class TestSearchResult:
                                  )),
 
             schema_pb2.FieldData(type=DataType.JSON, field_name="normal_json_field", field_id=111,
-                scalars=schema_pb2.ScalarField(json_data=schema_pb2.JSONArray(data=[ujson.dumps({i: i for i in range(3)}).encode() for i in range(6)])),
+                scalars=schema_pb2.ScalarField(json_data=schema_pb2.JSONArray(data=[orjson.dumps({str(i): i for i in range(3)}) for i in range(6)])),
             ),
             schema_pb2.FieldData(type=DataType.JSON, field_name="$meta", field_id=112,
                 is_dynamic=True,
-                scalars=schema_pb2.ScalarField(json_data=schema_pb2.JSONArray(data=[ujson.dumps({str(i*100): i}).encode() for i in range(6)])),
+                scalars=schema_pb2.ScalarField(json_data=schema_pb2.JSONArray(data=[orjson.dumps({str(i*100): i}) for i in range(6)])),
             ),
 
             schema_pb2.FieldData(type=DataType.FLOAT_VECTOR, field_name="float_vector_field", field_id=113,


### PR DESCRIPTION
Replace `ujson` with `orjson` in `pymilvus`

This fork was created to resolve a license issue which prevents us from using `pymilvus` - an official Python SDK for Milvus VDB. `pymilvus` uses `ujson` as a primary tool for json operations but it has an incompatible license for us, so we can't use it.
Also `ujson` has many other issues and even their [repo homepage](https://github.com/ultrajson/ultrajson) says:

> Warning
UltraJSON's architecture is fundamentally ill-suited to making changes without risk of introducing new security vulnerabilities. As a result, this library has been put into a maintenance-only mode. Support for new Python versions will be added and critical bugs and security issues will still be fixed but all other changes will be rejected. Users are encouraged to migrate to [orjson](https://pypi.org/project/orjson/) which is both much faster and less likely to introduce a surprise buffer overflow vulnerability in the future.

This fork is meant to be temporary and will be deleted as soon as PR to `pymilvus` will be merged. But it can take some time.